### PR TITLE
Support creation of IAM role for Cloudwatch logs.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ module.exports = function (serverless) {
         'before:deploy:deploy': function () {
             serverless.cli.log('Commencing API Gateway stage configuration');
 
+            const logRoleLogicalName = 'IamRoleApiGatewayCloudwatchLogRole';
             const stageSettings = serverless.service.custom.stageSettings || {};
             const template = serverless.service.provider.compiledCloudFormationTemplate;
             const deployments = _(template.Resources)
@@ -14,6 +15,89 @@ module.exports = function (serverless) {
 
             // TODO Handle other resources - ApiKey, BasePathMapping, UsagePlan, etc
             _.extend(template.Resources,
+                // Enable logging: IAM role for API Gateway, and API Gateway account settings
+                {
+                    [logRoleLogicalName]: {
+                        Type: 'AWS::IAM::Role',
+                        Properties: {
+                            AssumeRolePolicyDocument: {
+                                Version: '2012-10-17',
+                                Statement: [
+                                    {
+                                        Effect: 'Allow',
+                                        Principal: {
+                                            Service: [
+                                                'apigateway.amazonaws.com'
+                                            ]
+                                        },
+                                        Action: [
+                                            'sts:AssumeRole'
+                                        ]
+                                    }
+                                ]
+                            },
+                            Policies: [
+                                {
+                                    PolicyName: {
+                                        'Fn::Join': [
+                                            '-',
+                                            [
+                                                serverless.service.provider.stage,
+                                                serverless.service.service,
+                                                'apiGatewayLogs'
+                                            ]
+                                        ]
+                                    },
+                                    PolicyDocument: {
+                                        Version: '2012-10-17',
+                                        Statement: [
+                                            {
+                                                Effect: 'Allow',
+                                                Action: [
+                                                    'logs:CreateLogGroup',
+                                                    'logs:CreateLogStream',
+                                                    'logs:DescribeLogGroups',
+                                                    'logs:DescribeLogStreams',
+                                                    'logs:PutLogEvents',
+                                                    'logs:GetLogEvents',
+                                                    'logs:FilterLogEvents'
+                                                ],
+                                                Resource: '*'
+                                            }
+                                        ]
+                                    }
+                                }
+                            ],
+                            Path: '/',
+                            RoleName: {
+                                'Fn::Join': [
+                                    '-',
+                                    [
+                                        serverless.service.service,
+                                        serverless.service.provider.stage,
+                                        serverless.service.provider.region,
+                                        'apiGatewayLogRole'
+                                    ]
+                                ]
+                            }
+                        }
+                    },
+                    ApiGatewayAccount: {
+                        Type: 'AWS::ApiGateway::Account',
+                        Properties: {
+                            CloudWatchRoleArn: {
+                                'Fn::GetAtt': [
+                                    logRoleLogicalName,
+                                    'Arn'
+                                ]
+                            }
+                        },
+                        DependsOn: [
+                            logRoleLogicalName
+                        ]
+                    }
+                },
+
                 // Stages, one per deployment.  TODO Support multiple stages?
                 deployments
                     .mapValues((deployment, deploymentKey) => ({

--- a/test/mock/serverless.js
+++ b/test/mock/serverless.js
@@ -6,6 +6,8 @@ module.exports = (service, stageName, deploymentKey, stageSettings) => ({
     service: {
         service: service,
         provider: {
+            stage: stageName,
+            region: 'test-region',
             compiledCloudFormationTemplate: {
                 Resources: {
                     [deploymentKey]: {


### PR DESCRIPTION
+ Create IAM Role resource with relevant permissions.
+ Create API Gateway Account resource to specify the IAM role name.