### PR TITLE
feat(caching): add caching ability

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,17 +34,21 @@ plugins:
 #...
 custom:
   stageSettings:
+    CacheClusterEnabled: true
+    CacheClusterSize: '0.5'
     Variables:
       foo: bar
       baz: xyzzy
     MethodSettings:
       LoggingLevel: INFO
+      CachingEnabled: true
+      CacheTtlInSeconds: 3600
       # see below...
 #...
 ```
 
 The full list of `MethodSettings` available are defined in the 
-[AWS CloudFormation documentation](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apitgateway-stage-methodsetting.html).
+[AWS CloudFormation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigateway-stage-methodsetting.html).
 
 ## Contributors
 

--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ module.exports = function (serverless) {
                                         'Fn::Join': [
                                             '-',
                                             [
-                                                serverless.service.provider.stage,
+                                                serverless.getProvider('aws').getStage(),
                                                 serverless.service.service,
                                                 'apiGatewayLogs'
                                             ]
@@ -74,8 +74,8 @@ module.exports = function (serverless) {
                                     '-',
                                     [
                                         serverless.service.service,
-                                        serverless.service.provider.stage,
-                                        serverless.service.provider.region,
+                                        serverless.getProvider('aws').getStage(),
+                                        serverless.getProvider('aws').getRegion(),
                                         'apiGatewayLogRole'
                                     ]
                                 ]

--- a/src/index.js
+++ b/src/index.js
@@ -112,6 +112,8 @@ module.exports = function (serverless) {
                                 Ref: deploymentKey
                             },
                             Variables: stageSettings.Variables || {},
+                            CacheClusterEnabled: stageSettings.CacheClusterEnabled || false,
+                            CacheClusterSize: stageSettings.CacheClusterSize || '0.5',
                             MethodSettings: [
                                 _.defaults(
                                     stageSettings.MethodSettings || {},

--- a/test/mock/serverless.js
+++ b/test/mock/serverless.js
@@ -6,8 +6,6 @@ module.exports = (service, stageName, deploymentKey, stageSettings) => ({
     service: {
         service: service,
         provider: {
-            stage: stageName,
-            region: 'test-region',
             compiledCloudFormationTemplate: {
                 Resources: {
                     [deploymentKey]: {
@@ -24,6 +22,10 @@ module.exports = (service, stageName, deploymentKey, stageSettings) => ({
             stageSettings: stageSettings
         }
     },
+    getProvider: () => ({
+      getStage: () => stageName,
+      getRegion: () => 'test-region',
+    }),
     cli: {
         log: sinon.spy()
     }

--- a/test/spec/index.spec.js
+++ b/test/spec/index.spec.js
@@ -75,7 +75,10 @@ describe('The `serverless-api-stage` plugin', function () {
                 },
                 MethodSettings: {
                     LoggingLevel: 'INFO',
-                    MetricsEnabled: true
+                    MetricsEnabled: true,
+                    HttpMethod: 'GET',
+                    CacheTtlInSeconds: 3600,
+                    CachingEnabled: true
                 }
             });
             pluginInstance = new ApiStagePlugin(serverless);
@@ -187,8 +190,10 @@ describe('The `serverless-api-stage` plugin', function () {
                         MethodSettings: [
                             {
                                 LoggingLevel: 'INFO',
+                                CacheTtlInSeconds: 3600,
+                                CachingEnabled: true,
                                 DataTraceEnabled: true,
-                                HttpMethod: '*',
+                                HttpMethod: 'GET',
                                 ResourcePath: '/*',
                                 MetricsEnabled: true
                             }

--- a/test/spec/index.spec.js
+++ b/test/spec/index.spec.js
@@ -39,6 +39,8 @@ describe('The `serverless-api-stage` plugin', function () {
                         RestApiId: {
                             Ref: 'ApiGatewayRestApi'
                         },
+                        CacheClusterEnabled: false,
+                        CacheClusterSize: '0.5',
                         DeploymentId: {
                             Ref: 'Deployment'
                         },
@@ -66,6 +68,8 @@ describe('The `serverless-api-stage` plugin', function () {
         let serverless, pluginInstance;
         beforeEach(function () {
             serverless = mockServerless('service', 'testing', 'Deployment', {
+                CacheClusterEnabled: true,
+                CacheClusterSize: '1.0',
                 Variables: {
                     foo: 'bar'
                 },
@@ -172,6 +176,8 @@ describe('The `serverless-api-stage` plugin', function () {
                         RestApiId: {
                             Ref: 'ApiGatewayRestApi'
                         },
+                        CacheClusterEnabled: true,
+                        CacheClusterSize: '1.0',
                         DeploymentId: {
                             Ref: 'Deployment'
                         },


### PR DESCRIPTION
This PR will add the ability to enable caching for API Gateway.

To do so add:

```yaml
custom:
  # …
  stageSettings:
    CacheClusterEnabled: true
    CacheClusterSize: '0.5'
    MethodSettings:
      CachingEnabled: true
      CacheTtlInSeconds: 3600
```

See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html\#cfn-apigateway-stage-cacheclusterenabled form more info.