### PR TITLE
MethodSettings should be a list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-api-stage",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-api-stage",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Serverless API Stage plugin, enables stage variables and logging for AWS API Gateway.",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ module.exports = function (serverless) {
                 .pickBy((resource) => resource.Type === 'AWS::ApiGateway::Deployment');
 
             // TODO Handle other resources - ApiKey, BasePathMapping, UsagePlan, etc
+            const methodSettings = [].concat(stageSettings.MethodSettings);
             _.extend(template.Resources,
                 // Enable logging: IAM role for API Gateway, and API Gateway account settings
                 {
@@ -114,9 +115,9 @@ module.exports = function (serverless) {
                             Variables: stageSettings.Variables || {},
                             CacheClusterEnabled: stageSettings.CacheClusterEnabled || false,
                             CacheClusterSize: stageSettings.CacheClusterSize || '0.5',
-                            MethodSettings: [
+                            MethodSettings: methodSettings.map(item => (
                                 _.defaults(
-                                    stageSettings.MethodSettings || {},
+                                    item || {},
                                     {
                                         DataTraceEnabled: true,
                                         HttpMethod: '*',
@@ -124,7 +125,7 @@ module.exports = function (serverless) {
                                         MetricsEnabled: false
                                     }
                                 )
-                            ]
+                            ))
                         }
                     }))
                     .mapKeys((deployment, deploymentKey) => `ApiGatewayStage${_.upperFirst(deployment.Properties.StageName)}`)


### PR DESCRIPTION
Thanks again for the plugins.

According to [the docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-stage.html#cfn-apigateway-stage-methodsettings) `MethodSettings` should be an array of objects. However the plugin only takes a single object and makes it into an array of one position.

This PR will allow specifying multiple method settings while maintaining backwards compatibility for the existing installs.