### PR TITLE
Modify CF template before nested stacks get created

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ const _ = require('lodash');
 
 module.exports = function (serverless) {
     this.hooks = {
-        'before:deploy:deploy': function () {
+        'before:package:finalize': function () {
             serverless.cli.log('Commencing API Gateway stage configuration');
 
             const logRoleLogicalName = 'IamRoleApiGatewayCloudwatchLogRole';


### PR DESCRIPTION
We're using serverless-plugin-split-stacks to split the resulting CF template into nested stacks. This occurs on `after:aws:package:finalize:mergeCustomProviderResources` which is part of `package:finalize`. Because of this the Stage gets added too late and leads to errors when deploying it to AWS.

This PR moves the modifications from this plugin to the beginning of `package:finalize` to fix that.