### PR TITLE
Add support for shared API Gateway

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -106,9 +106,9 @@ module.exports = function (serverless) {
                         Properties: {
                             StageName: deployment.Properties.StageName,
                             Description: `${deployment.Properties.StageName} stage of ${serverless.service.service}`,
-                            RestApiId: {
-                                Ref: _.get(serverless, 'service.provider.apiGateway.restApiId', 'ApiGatewayRestApi')
-                            },
+                            RestApiId: _.get(serverless, 'service.provider.apiGateway.restApiId', {
+                                Ref: 'ApiGatewayRestApi'
+                            }),
                             DeploymentId: {
                                 Ref: deploymentKey
                             },

--- a/src/index.js
+++ b/src/index.js
@@ -107,7 +107,7 @@ module.exports = function (serverless) {
                             StageName: deployment.Properties.StageName,
                             Description: `${deployment.Properties.StageName} stage of ${serverless.service.service}`,
                             RestApiId: {
-                                Ref: 'ApiGatewayRestApi'
+                                Ref: _.get(serverless, 'service.provider.apiGateway.restApiId', 'ApiGatewayRestApi')
                             },
                             DeploymentId: {
                                 Ref: deploymentKey

--- a/test/mock/serverless.js
+++ b/test/mock/serverless.js
@@ -2,7 +2,7 @@
 
 const sinon = require('sinon');
 
-module.exports = (service, stageName, deploymentKey, stageSettings) => ({
+module.exports = (service, stageName, deploymentKey, stageSettings, apiGateway) => ({
     service: {
         service: service,
         provider: {
@@ -16,7 +16,8 @@ module.exports = (service, stageName, deploymentKey, stageSettings) => ({
                         }
                     }
                 }
-            }
+            },
+            apiGateway
         },
         custom: {
             stageSettings: stageSettings

--- a/test/spec/index.spec.js
+++ b/test/spec/index.spec.js
@@ -499,7 +499,7 @@ describe('The `serverless-api-stage` plugin', function () {
                 pluginInstance.hooks['before:deploy:deploy']();
             });
             it('Adds an API Gateway Stage resource to the CloudFormation template with specified variables and settings', function () {
-                expect(serverless.service.provider.compiledCloudFormationTemplate.Resources.ApiGatewayStageTesting.Properties.RestApiId.Ref).to.equal(serverless.service.provider.apiGateway.restApiId);
+                expect(serverless.service.provider.compiledCloudFormationTemplate.Resources.ApiGatewayStageTesting.Properties.RestApiId).to.equal(serverless.service.provider.apiGateway.restApiId);
             });
         });
     });

--- a/test/spec/index.spec.js
+++ b/test/spec/index.spec.js
@@ -488,4 +488,19 @@ describe('The `serverless-api-stage` plugin', function () {
             });
         });
     });
+    describe('Using non default restApiId`', function () {
+        let serverless, pluginInstance;
+        beforeEach(function () {
+            serverless = mockServerless('service', 'testing', 'Deployment', {},  {restApiId: 'foobar'});
+            pluginInstance = new ApiStagePlugin(serverless);
+        });
+        describe('When the `before:deploy:deploy` hook is executed', function () {
+            beforeEach(function () {
+                pluginInstance.hooks['before:deploy:deploy']();
+            });
+            it('Adds an API Gateway Stage resource to the CloudFormation template with specified variables and settings', function () {
+                expect(serverless.service.provider.compiledCloudFormationTemplate.Resources.ApiGatewayStageTesting.Properties.RestApiId.Ref).to.equal(serverless.service.provider.apiGateway.restApiId);
+            });
+        });
+    });
 });


### PR DESCRIPTION
When a [Shared API Gateway](https://serverless.com/framework/docs/providers/aws/events/apigateway/) is configured, the rest api id will be taken from the serverless configuration rather than default.  

Closes #22 